### PR TITLE
Update braintree in gemspec

### DIFF
--- a/lib/solidus_paypal_braintree/version.rb
+++ b/lib/solidus_paypal_braintree/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SolidusPaypalBraintree
-  VERSION = '1.1.1'
+  VERSION = '1.1.2'
 end

--- a/solidus_paypal_braintree.gemspec
+++ b/solidus_paypal_braintree.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   end
 
   s.add_dependency 'activemerchant', '~> 1.48'
-  s.add_dependency 'braintree', '~> 4.0.0'
+  s.add_dependency 'braintree', '~> 4.0'
   s.add_dependency 'solidus_api', ['>= 2.0.0', '< 4']
   s.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   s.add_dependency 'solidus_support', ['>= 0.8.1', '< 1']

--- a/solidus_paypal_braintree.gemspec
+++ b/solidus_paypal_braintree.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   end
 
   s.add_dependency 'activemerchant', '~> 1.48'
-  s.add_dependency 'braintree', '~> 3.4'
+  s.add_dependency 'braintree', '~> 4.0.0'
   s.add_dependency 'solidus_api', ['>= 2.0.0', '< 4']
   s.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   s.add_dependency 'solidus_support', ['>= 0.8.1', '< 1']


### PR DESCRIPTION
According to [this issue](https://github.com/braintree/braintree_ruby/issues/205), bumping the version of the `braintree-ruby` gem to 4.0.0 makes `libxml` library optional (and potentially replaces it with nokogiri). I believe that will fix the libxml C compliation error on Apple Silicon while also avoiding the `NoMethodError` that OMS encountered when processing Braintree payments for CatchCo rebill.

Tested by publishing a new version of this gem on my workstation, configured the OMS gemfile to use that version of the `solidus_paypal_braintree` instead of the one from github, then completed orders using Braintree payment sources. The XML responses were parsed successfully and the orders were completed.

<img width="1165" alt="image" src="https://github.com/chordcommerce/solidus_paypal_braintree/assets/7190681/8aaaa76b-2083-4f62-828d-763b61fa437f">

Looking through the various `Gemfile.lock` files, I do not see any reference to `libxml`, so I assume that means that `solidus_paypal_braintree` is now using nokogiri.

It goes without saying, that since I was able to perform the test above, this issue resolves the compilation issue on Apple Silicon chips.

# Impact of updating libxml

To demonstrate that this PR actually fixes both issues, I rolled my workstation back to the previous version of `solidus_paypal_braintree` gem and performed another test. This version of the gem uses a newer version of libxml gem (5.x), which compiles on my workstation. The order failed with the following error (which is the same OMS encountered when parsing CatchCo rebills on June 1).

```
NoMethodError - undefined method `default_keep_blanks=' for LibXML::XML:Module
Did you mean?  default_tree_indent_string=:
  app/services/chord/order_transition/complete_order.rb:33:in `complete_order'
  app/services/chord/order_transition/complete_order.rb:21:in `call'
  app/services/chord/order_transition/complete_order.rb:8:in `call'
  app/decorators/controllers/spree/admin/orders_controller_decorator.rb:75:in `complete'
  lib/middleware/acs/response_status_metric.rb:8:in `call'
```

# Compilation error

For a final demonstration, I switched to the current main branch and ran `bundle`. I received the following error when my workstation compiled libxml 3.2.3:

```
ruby_xml_encoding.c:200:3: error: incompatible function pointer types passing 'VALUE (VALUE, VALUE)' (aka 'unsigned long (unsigned long, unsigned
long)') to parameter of type 'VALUE (*)(VALUE, VALUE, VALUE)' (aka 'unsigned long (*)(unsigned long, unsigned long, unsigned long)')
```